### PR TITLE
Upgrade to TensorFlow 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,8 @@ pip install address-net[tf]     # install TensorFlow (CPU version)
 pip install address-net[tf_gpu] # install TensorFlow (GPU version)
 ```
 
-You will need an appropriate version of TensorFlow installed, ideally greater
-than version 1.12. This is not automatically installed since the CPU and GPU
-versions of TensorFlow exist in separate packages.
+You will need TensorFlow 2 installed. This is not automatically installed since
+the CPU and GPU versions of TensorFlow exist in separate packages.
 
 ## Model output
 This model performs character-level classification, assigning each

--- a/addressnet/dataset.py
+++ b/addressnet/dataset.py
@@ -2,7 +2,8 @@ from typing import Optional, Union, Callable, List
 from collections import OrderedDict
 
 import random
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
+tf.disable_v2_behavior()
 import numpy as np
 import string
 

--- a/addressnet/model.py
+++ b/addressnet/model.py
@@ -1,6 +1,7 @@
 from typing import Dict, Optional
 
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
+tf.disable_v2_behavior()
 
 from addressnet.dataset import vocab, n_labels
 

--- a/addressnet/predict.py
+++ b/addressnet/predict.py
@@ -1,7 +1,8 @@
 import os
 from typing import Dict, List, Union
 import textdistance
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
+tf.disable_v2_behavior()
 
 from addressnet.dataset import predict_input_fn, labels_list
 from addressnet.lookups import street_types, street_type_abbreviation, states, street_suffix_types, flat_types, \

--- a/generate_tf_records.py
+++ b/generate_tf_records.py
@@ -1,6 +1,7 @@
 import gzip
 import csv
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
+tf.disable_v2_behavior()
 import argparse
 
 from addressnet.lookups import lookup_flat_type, lookup_level_type, lookup_street_type, lookup_street_suffix, \

--- a/setup.py
+++ b/setup.py
@@ -10,8 +10,8 @@ setup(
     author_email='hello@jasonrig.by',
     description='Splits Australian addresses into their components',
     extras_require={
-        "tf": ["tensorflow>=1.12,<2.0"],
-        "tf_gpu": ["tensorflow-gpu>=1.12,<2.0"],
+        "tf": ["tensorflow>=2.0,<3.0"],
+        "tf_gpu": ["tensorflow-gpu>=2.0,<3.0"],
     },
     install_requires=[
         'numpy',


### PR DESCRIPTION
## Summary
- move imports to `tensorflow.compat.v1` and disable v2 behaviour
- bump TensorFlow requirement to v2 in setup
- update README to note TensorFlow 2 requirement

## Testing
- `python -m compileall -q addressnet generate_tf_records.py predict.py setup.py`