### PR TITLE
Add tensorflow_estimator integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Or from PyPI:
 pip install address-net
 pip install address-net[tf]     # install TensorFlow (CPU version)
 pip install address-net[tf_gpu] # install TensorFlow (GPU version)
+pip install tensorflow-estimator # required for the estimator API
 ```
 
 You will need TensorFlow 2 installed. This is not automatically installed since

--- a/addressnet/predict.py
+++ b/addressnet/predict.py
@@ -3,6 +3,7 @@ from typing import Dict, List, Union
 import textdistance
 import tensorflow.compat.v1 as tf
 tf.disable_v2_behavior()
+import tensorflow_estimator as tf_estimator
 
 from addressnet.dataset import predict_input_fn, labels_list
 from addressnet.lookups import street_types, street_type_abbreviation, states, street_suffix_types, flat_types, \
@@ -109,8 +110,8 @@ def normalise_level_type(s: str) -> str:
 
 @lru_cache(maxsize=2)
 def _get_estimator(model_fn, model_dir):
-    return tf.estimator.Estimator(model_fn=model_fn,
-                                  model_dir=model_dir)
+    return tf_estimator.estimator.Estimator(model_fn=model_fn,
+                                            model_dir=model_dir)
 
 
 def predict_one(address: str, model_dir: str = None) -> Dict[str, str]:

--- a/setup.py
+++ b/setup.py
@@ -10,8 +10,8 @@ setup(
     author_email='hello@jasonrig.by',
     description='Splits Australian addresses into their components',
     extras_require={
-        "tf": ["tensorflow>=2.0,<3.0"],
-        "tf_gpu": ["tensorflow-gpu>=2.0,<3.0"],
+        "tf": ["tensorflow>=2.0,<3.0", "tensorflow-estimator>=2.0,<3.0"],
+        "tf_gpu": ["tensorflow-gpu>=2.0,<3.0", "tensorflow-estimator>=2.0,<3.0"],
     },
     install_requires=[
         'numpy',

--- a/tests/http_endpoint.py
+++ b/tests/http_endpoint.py
@@ -1,0 +1,86 @@
+import json
+import os
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from urllib.parse import parse_qs, urlparse
+
+
+def _predict_address(address: str, model_dir: str | None = None):
+    import tensorflow.compat.v1 as tf
+    import tensorflow_estimator as tf_estimator
+    from addressnet.predict import labels_list, predict_input_fn
+    from addressnet.model import model_fn
+    if model_dir is None:
+        model_dir = os.path.join(os.path.dirname(__file__), '..', 'addressnet', 'pretrained')
+    model_dir = os.path.abspath(model_dir)
+    estimator = tf_estimator.estimator.Estimator(model_fn=model_fn, model_dir=model_dir)
+    result_iter = estimator.predict(predict_input_fn([address]))
+    res = next(result_iter)
+    class_ids = res['class_ids']
+    probs = res['probabilities']
+    class_names = [l.replace('_code', '') for l in labels_list]
+    class_names = [l.replace('_abbreviation', '') for l in class_names]
+    mapping = {}
+    conf_vals = []
+    for char, cid, prob in zip(address.upper(), class_ids, probs):
+        if cid == 0:
+            continue
+        conf_vals.append(prob[cid])
+        cls = class_names[cid - 1]
+        mapping[cls] = mapping.get(cls, '') + char
+    confidence = float(sum(conf_vals) / len(conf_vals)) if conf_vals else 0.0
+    return mapping, confidence
+
+
+_COMPONENT_ORDER = [
+    'building_name',
+    'flat_type',
+    'flat_number',
+    'flat_number_suffix',
+    'level_type',
+    'level_number',
+    'number_first',
+    'number_last',
+    'street_name',
+    'street_type',
+    'street_suffix',
+    'locality_name',
+    'state',
+    'postcode',
+]
+
+
+def _format_address(parts: dict) -> str:
+    ordered = []
+    for key in _COMPONENT_ORDER:
+        if key in parts:
+            ordered.append(str(parts[key]))
+    return ' '.join(ordered)
+
+
+class AddressHandler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        parsed = urlparse(self.path)
+        if parsed.path != '/predict':
+            self.send_error(404, 'not found')
+            return
+        qs = parse_qs(parsed.query)
+        if 'address' not in qs:
+            self.send_error(400, 'address parameter missing')
+            return
+        address = qs['address'][0]
+        mapping, conf = _predict_address(address)
+        reformatted = _format_address(mapping)
+        payload = {'input': address, 'reformatted': reformatted, 'confidence': conf}
+        body = json.dumps(payload).encode('utf-8')
+        self.send_response(200)
+        self.send_header('Content-Type', 'application/json')
+        self.send_header('Content-Length', str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+
+if __name__ == '__main__':
+    port = 8000
+    server = HTTPServer(('0.0.0.0', port), AddressHandler)
+    print(f'Serving on port {port}')
+    server.serve_forever()

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -1,0 +1,35 @@
+import sys, os
+sys.path.insert(0, os.path.dirname(__file__))
+import json
+import threading
+from http.server import HTTPServer
+
+import requests
+import pytest
+
+import http_endpoint
+
+
+def test_http_endpoint(monkeypatch):
+    def fake_predict(address, model_dir=None):
+        return {'street_name': 'HIGH', 'street_type': 'STREET'}, 0.95
+
+    monkeypatch.setattr(http_endpoint, '_predict_address', fake_predict)
+
+    server = HTTPServer(('localhost', 0), http_endpoint.AddressHandler)
+    thread = threading.Thread(target=server.serve_forever)
+    thread.daemon = True
+    thread.start()
+
+    try:
+        url = f'http://localhost:{server.server_port}/predict'
+        resp = requests.get(url, params={'address': '10 High Street'})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data['input'] == '10 High Street'
+        assert data['reformatted'] == 'HIGH STREET'
+        assert data['confidence'] == 0.95
+    finally:
+        server.shutdown()
+        thread.join()
+


### PR DESCRIPTION
## Summary
- reference `tensorflow_estimator` instead of `tf.estimator`
- document estimator dependency in README
- include `tensorflow-estimator` in setup extras
- update sample endpoint to use the new import

## Testing
- `pytest -q`
