### PR TITLE
Add HTTP endpoint instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,3 +129,20 @@ Because the model is not sensitive to small typographical errors, a
 simple string similarity algorithm is used to normalise fields such as
 `street_type` and `state`, since we know exhaustively what they should
 be.
+
+## HTTP endpoint test
+A small HTTP server for manual testing is provided in `tests/http_endpoint.py`. Make sure TensorFlow and the `tensorflow-estimator` package are installed, then run:
+
+```
+python tests/http_endpoint.py
+```
+
+The server listens on port 8000. Query it with curl, for example:
+
+```
+curl "http://localhost:8000/predict?address=10%20High%20Street"
+```
+
+The response contains the reformatted address and a confidence score.
+
+


### PR DESCRIPTION
## Summary
- add a new section in README with instructions for running `tests/http_endpoint.py`
- document how to query the endpoint using curl
- mention TensorFlow and `tensorflow-estimator` requirements

## Testing
- `pytest -q`